### PR TITLE
Loosen up BatchLoadFn TS definition, Promise -> PromiseLike

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -72,7 +72,7 @@ declare namespace DataLoader {
 
   // A Function, which when given an Array of keys, returns a Promise of an Array
   // of values or Errors.
-  export type BatchLoadFn<K, V> = (keys: K[]) => Promise<Array<V | Error>>;
+  export type BatchLoadFn<K, V> = (keys: K[]) => PromiseLike<Array<V | Error>>;
 
   // Optionally turn off batching or caching or provide a cache key function or a
   // custom cache instance.


### PR DESCRIPTION
Given than DataLoader only [checks that](https://github.com/facebook/dataloader/blob/420e62f2d424122bfad127d9a7f571d091563894/src/index.js#L260-L266) a batch loader is "thenable", changing the TS def from `Promise<Array<V | Error>>` to `PromiseLike<Array<V | Error>>` better matches the intent - any object which matches the promise `.then` signature.

This is useful when returning promises from Bluebird, which [utilizes the `PromiseLike` interface](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3c6a83e0b309f7d02e4627ef5d234d64059a8641/types/bluebird/index.d.ts#L40) but doesn't conform to the `Symbol.toStringTag` TypeScript [uses to check](https://github.com/Microsoft/TypeScript/blob/291e44e7e3c22f7fd89266bbeae15531f9ad90a8/src/lib/es2015.symbol.wellknown.d.ts#L148-L150) for the `Promise` type.

Otherwise I find myself wrapping the Bluebird promises in an extra `Promise.resolve` just to type-check.