### PR TITLE
Deactivate Prime fonction when cache is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ method chaining.
 Primes the cache with the provided key and value. If the key already exists, no
 change is made. (To forcefully prime the cache, clear the key first with
 `loader.clear(key).prime(key, value)`.) Returns itself for method chaining.
+If the cache is disable, prime will do nothing.
 
 
 ## Using with GraphQL

--- a/src/__tests__/dataloader-test.js
+++ b/src/__tests__/dataloader-test.js
@@ -529,6 +529,29 @@ describe('Accepts options', () => {
     ]);
   });
 
+  it('Prime will do nothing when cache disabled', async () => {
+    var [ identityLoader, loadCalls ] = idLoader({ cache: false });
+
+    var [ values1, values2, values3, values4 ] = await Promise.all([
+      identityLoader.load('A'),
+      identityLoader.load('C'),
+      identityLoader.load('D'),
+      identityLoader.loadMany([ 'C', 'D', 'A', 'A', 'B' ]),
+    ]);
+
+    var key1 = { id: 123 };
+    identityLoader.prime(key1, key1);
+
+    expect(values1).to.equal('A');
+    expect(values2).to.equal('C');
+    expect(values3).to.equal('D');
+    expect(values4).to.deep.equal([ 'C', 'D', 'A', 'A', 'B' ]);
+
+    expect(loadCalls).to.deep.equal([
+      [ 'A', 'C', 'D', 'C', 'D', 'A', 'A', 'B' ]
+    ]);
+  });
+
   it('Complex cache behavior via clearAll()', async () => {
     // This loader clears its cache as soon as a batch function is dispatched.
     var loadCalls = [];

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,10 @@ class DataLoader<K, V> {
     var cacheKey = cacheKeyFn ? cacheKeyFn(key) : key;
 
     // Only add the key if it does not already exist.
-    if (this._promiseCache.get(cacheKey) === undefined) {
+    if (
+      (!this._options || this._options.cache !== false) &&
+      this._promiseCache.get(cacheKey) === undefined
+    ) {
       // Cache a rejected promise if the value is an Error, in order to match
       // the behavior of load(key).
       var promise = value instanceof Error ?


### PR DESCRIPTION
I recently used DataLoader and I implemented in one of my program. After implementing a lot of them I saw that I needed a huge amount of ram using the default Map implementation.
I decided to disable cache for all implementation. Nevertheless, the prime functions that I used in my code were still caching and increased the amount of ram.

After investigation, it seems that the prime function doesn't look for option.cached.

The pull request is there to solve this issue.

To reproduce the issue, you can see the section *Loading by alternative keys* (See README.md) and add caching false to `userByIDLoader`. You will see that using `usernameLoader` it will cache some values even if you don't want to.