### PR TITLE
Add GraphQL-Batch to Ruby implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Looking to get started with a specific back-end? Try the [loaders in the example
 * PHP
   * [DataLoaderPHP](https://github.com/overblog/dataloader-php)
 * Ruby
+  * [GraphQL Batch](https://github.com/Shopify/graphql-batch)
   * [Dataloader](https://github.com/sheerun/dataloader)
   * [BatchLoader](https://github.com/exaspark/batch-loader)
 * ReasonML


### PR DESCRIPTION
I'm writing a post on the dataloader style pattern and while looking at the readme to link it in the post I  noticed that the README didn't mention https://github.com/Shopify/graphql-batch This is used heavily at both Shopify and GitHub, think it deserves to be linked here 👍 