### PR TITLE
Add Perl port to 'Other Implementations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ Looking to get started with a specific back-end? Try the [loaders in the example
   * [Dataloader](https://github.com/nicksrandall/dataloader)
 * Rust
   * [Dataloader](https://github.com/cksac/dataloader-rs)
+* Perl
+  * [perl-DataLoader](https://github.com/richardjharris/perl-DataLoader)
 
 ## Video Source Code Walkthrough
 


### PR DESCRIPTION
I have ported dataloader to Perl for use with the GraphQL perl module, as nobody else seems to have done it: https://github.com/richardjharris/perl-DataLoader