### PR TITLE
Set cacheKeyFn arg type as K

### DIFF
--- a/src/__tests__/dataloader-test.js
+++ b/src/__tests__/dataloader-test.js
@@ -557,7 +557,7 @@ describe('Accepts options', () => {
   });
 
   describe('Accepts object key in custom cacheKey function', () => {
-    function cacheKey(key) {
+    function cacheKey(key: any) {
       return Object.keys(key).sort().map(k => k + ':' + key[k]).join();
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -102,7 +102,7 @@ declare namespace DataLoader {
      * objects are keys and two similarly shaped objects should
      * be considered equivalent.
      */
-    cacheKeyFn?: (key: any) => any,
+    cacheKeyFn?: (key: K) => any,
 
     /**
      * An instance of Map (or an object with a similar API) to

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export type Options<K, V> = {
   batch?: boolean;
   maxBatchSize?: number;
   cache?: boolean;
-  cacheKeyFn?: (key: any) => any;
+  cacheKeyFn?: (key: K) => any;
   cacheMap?: CacheMap<K, Promise<V>>;
 };
 


### PR DESCRIPTION
Previously it was set to `any`. I had to add an explicit `any` annotation in the test file otherwise it created loads of flow errors.