### PR TITLE
Check that caching is enabled before using it

### DIFF
--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -542,6 +542,19 @@ describe('Accepts options', () => {
     ]);
   });
 
+  it('Does not interact with a cache when cache is disabled', () => {
+    const promiseX = Promise.resolve('X');
+    const cacheMap = new Map([ [ 'X', promiseX ] ]);
+    const [ identityLoader ] = idLoader({ cache: false, cacheMap });
+
+    identityLoader.prime('A', 'A');
+    expect(cacheMap.get('A')).toBe(undefined);
+    identityLoader.clear('X');
+    expect(cacheMap.get('X')).toBe(promiseX);
+    identityLoader.clearAll();
+    expect(cacheMap.get('X')).toBe(promiseX);
+  });
+
   it('Complex cache behavior via clearAll()', async () => {
     // This loader clears its cache as soon as a batch function is dispatched.
     const loadCalls = [];


### PR DESCRIPTION
The existing behavior for a DataLoader with caching disabled is to still create a cache Map, which allows the `prime()` and `clear()` methods to continue to interact with that cache even though nothing will read from it. A classic "write-only cache"!

This fixes this behavior by not creating a cache Map for DataLoaders with caching disabled and checks for this case before interacting with the cache.

Fixes #161