### PR TITLE
[BREAKING] loadMany() returns individual Error instead of rejecting promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,22 @@ Loads multiple keys, promising an array of values:
 const [ a, b ] = await myLoader.loadMany([ 'a', 'b' ])
 ```
 
-This is equivalent to the more verbose:
+This is similar to the more verbose:
 
 ```js
 const [ a, b ] = await Promise.all([
   myLoader.load('a'),
   myLoader.load('b')
 ])
+```
+
+However it is different in the case where any load fails. Where
+Promise.all() would reject, loadMany() always resolves, however each result
+is either a value or an Error instance.
+
+```js
+var [ a, b, c ] = await myLoader.loadMany([ 'a', 'b', 'badkey' ]);
+// c instanceof Error
 ```
 
 - *keys*: An array of key values to load.

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -62,6 +62,20 @@ describe('Primary API', () => {
     expect(empty).toEqual([]);
   });
 
+  it('supports loading multiple keys in one call with errors', async () => {
+    const identityLoader = new DataLoader(keys =>
+      Promise.resolve(
+        keys.map(key => (key === 'bad' ? new Error('Bad Key') : key))
+      )
+    );
+
+    const promiseAll = identityLoader.loadMany([ 'a', 'b', 'bad' ]);
+    expect(promiseAll).toBeInstanceOf(Promise);
+
+    const values = await promiseAll;
+    expect(values).toEqual([ 'a', 'b', new Error('Bad Key') ]);
+  });
+
   it('batches multiple requests', async () => {
     const [ identityLoader, loadCalls ] = idLoader<number>();
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,7 +37,7 @@ declare class DataLoader<K, V, C = K> {
    *     ]);
    *
    */
-  loadMany(keys: ArrayLike<K>): Promise<V[]>;
+  loadMany(keys: ArrayLike<K>): Promise<Array<V | Error>>;
 
   /**
    * Clears the value at `key` from the cache, if it exists. Returns itself for


### PR DESCRIPTION
This changes the behavior of loadMore() to return `Promise<Array<V | Error>>` which always resolves, instead of the previous `Promise<Array<V>>` which rejects if any one of the requested values fails.

This makes this method meaningfully useful beyond a simple `Promise.all()`