### PR TITLE
[BUG] Fix types for prime() to allow priming an Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Primes the cache with the provided key and value. If the key already exists, no
 change is made. (To forcefully prime the cache, clear the key first with
 `loader.clear(key).prime(key, value)`.) Returns itself for method chaining.
 
+To prime the cache with an error at a key, provide an Error instance.
 
 ## Using with GraphQL
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,7 @@ declare class DataLoader<K, V, C = K> {
    * Adds the provied key and value to the cache. If the key already exists, no
    * change is made. Returns itself for method chaining.
    */
-  prime(key: K, value: V): this;
+  prime(key: K, value: V | Error): this;
 }
 
 declare namespace DataLoader {

--- a/src/index.js
+++ b/src/index.js
@@ -172,8 +172,10 @@ class DataLoader<K, V, C = K> {
   /**
    * Adds the provided key and value to the cache. If the key already
    * exists, no change is made. Returns itself for method chaining.
+   *
+   * To prime the cache with an error at a key, provide an Error instance.
    */
-  prime(key: K, value: V): this {
+  prime(key: K, value: V | Error): this {
     var cache = this._promiseCache;
     if (cache) {
       var cacheKey = getCacheKey(this._options, key);


### PR DESCRIPTION
There is existing behavior to support priming the cache with an Error at a given key, however the Flow/TS types did not allow this. This fixes this type checking bug and includes this pattern in the documentation.