### PR TITLE
[FIX] Returns the keys type of the batch fn to ReadonlyArray

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ declare namespace DataLoader {
   // A Function, which when given an Array of keys, returns a Promise of an Array
   // of values or Errors.
   export type BatchLoadFn<K, V> =
-    (keys: ArrayLike<K>) => PromiseLike<ArrayLike<V | Error>>;
+    (keys: ReadonlyArray<K>) => PromiseLike<ArrayLike<V | Error>>;
 
   // Optionally turn off batching or caching or provide a cache key function or a
   // custom cache instance.


### PR DESCRIPTION
Fixes an issue caused by #214 where batch functions which attempt to use array methods like `map` or `filter` would become typescript errors. This retains the ArrayLike return type but provides ReadonlyArray for the keys argument to the function.