### PR TITLE
Refactor batching logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Create a new `DataLoader` given a batch loading function and options.
 
   | Option Key | Type | Default | Description |
   | ---------- | ---- | ------- | ----------- |
-  | *batch*  | Boolean | `true` | Set to `false` to disable batching, invoking `batchLoadFn` with a single load key.
+  | *batch*  | Boolean | `true` | Set to `false` to disable batching, invoking `batchLoadFn` with a single load key. This is equivalent to setting `maxBatchSize` to `1`.
   | *maxBatchSize* | Number | `Infinity` | Limits the number of items that get passed in to the `batchLoadFn`.
   | *cache* | Boolean | `true` | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key.
   | *cacheKeyFn* | Function | `key => key` | Produces cache key for a given load key. Useful when objects are keys and two objects should be considered equivalent.


### PR DESCRIPTION
This is a non-breaking refactor of DataLoader's batching logic meant to simplify the `load()` method, put a more understandable abstraction in place which can be a target for more complex behavior (such as #113)

It replaces the concept of a `LoaderQueue` with a `Batch`. It moves all logic for creating this datastructure into a dedicated function, and moves the logic for splitting a batch (`maxBatchSize`) to batch creation time rather than batch dispatch time, which simplifies the dispatch logic.