### PR TITLE
[BREAKING] Resolve cached values after batch dispatch

### DIFF
--- a/src/__tests__/unhandled.test.js
+++ b/src/__tests__/unhandled.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2019-present, GraphQL Foundation
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const DataLoader = require('..');
+
+describe('Unhandled rejections', () => {
+  it('Not catching a primed error is an unhandled rejection', async () => {
+    let hadUnhandledRejection = false;
+    // Override Jest's unhandled detection
+    global.jasmine.process.removeAllListeners('unhandledRejection');
+    global.jasmine.process.on('unhandledRejection', () => {
+      hadUnhandledRejection = true;
+    });
+
+    const identityLoader = new DataLoader<number, number>(async keys => keys);
+
+    identityLoader.prime(1, new Error('Error: 1'));
+
+    // Ignore result.
+    identityLoader.load(1);
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(hadUnhandledRejection).toBe(true);
+  });
+});


### PR DESCRIPTION
This is an alternate of #113, however when built atop the new `Batch` abstraction introduced in #220 the implementation becomes much simpler.

This change is breaking since it results in timing differences when cached values are resolved which can affect whole program behavior. However hopefully this behavior change is for the better since it should result in better whole-program optimization.

Fixes #224 
Closes #113
Fixes #97