### PR TITLE
[FIX] Fix case where priming an Error results in UnhandledPromiseRejection

### DIFF
--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -341,6 +341,9 @@ describe('Represents Errors', () => {
 
     identityLoader.prime(1, new Error('Error: 1'));
 
+    // Wait a bit.
+    await new Promise(setImmediate);
+
     let caughtErrorA;
     try {
       await identityLoader.load(1);
@@ -352,6 +355,35 @@ describe('Represents Errors', () => {
 
     expect(loadCalls).toEqual([]);
   });
+
+  // TODO: #224
+  /*
+  it('Not catching a primed error is an unhandled rejection', async () => {
+    let hadUnhandledRejection = false;
+    function onUnhandledRejection() {
+      hadUnhandledRejection = true;
+    }
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const [ identityLoader ] = idLoader<number>();
+
+      identityLoader.prime(1, new Error('Error: 1'));
+
+      // Wait a bit.
+      await new Promise(setImmediate);
+
+      // Ignore result.
+      identityLoader.load(1);
+
+      // Wait a bit.
+      await new Promise(setImmediate);
+
+      expect(hadUnhandledRejection).toBe(true);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandledRejection);
+    }
+  });
+  */
 
   it('Can clear values from cache after errors', async () => {
     const loadCalls = [];

--- a/src/index.js
+++ b/src/index.js
@@ -184,10 +184,15 @@ class DataLoader<K, V, C = K> {
       if (cache.get(cacheKey) === undefined) {
         // Cache a rejected promise if the value is an Error, in order to match
         // the behavior of load(key).
-        var promise = value instanceof Error ?
-          Promise.reject(value) :
-          Promise.resolve(value);
-
+        var promise;
+        if (value instanceof Error) {
+          promise = Promise.reject(value);
+          // Since this is a case where an Error is intentionally being primed
+          // for a given key, we want to disable unhandled promise rejection.
+          promise.catch(() => {});
+        } else {
+          promise = Promise.resolve(value);
+        }
         cache.set(cacheKey, promise);
       }
     }


### PR DESCRIPTION
Because the cache stores Promises instead of values, we need to store a rejected promise for error cases.

In the case we want to prime such an error, a new rejected Promise is created and stored for later access. This is an unhandled promise rejection. However this is an intentionally unhandled rejection since it is stored for later access.

However this also masks another minor bug (#224) where loading that primed Error but not handling it *should* result in an UnhandledPromiseRejection but does not.