### PR TITLE
Resolve all options during construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ Create a new `DataLoader` given a batch loading function and options.
   | Option Key | Type | Default | Description |
   | ---------- | ---- | ------- | ----------- |
   | *batch*  | Boolean | `true` | Set to `false` to disable batching, invoking `batchLoadFn` with a single load key. This is equivalent to setting `maxBatchSize` to `1`.
-  | *maxBatchSize* | Number | `Infinity` | Limits the number of items that get passed in to the `batchLoadFn`.
-  | *cache* | Boolean | `true` | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key.
+  | *maxBatchSize* | Number | `Infinity` | Limits the number of items that get passed in to the `batchLoadFn`. May be set to `1` to disable batching.
+  | *cache* | Boolean | `true` | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key. This is equivalent to setting `cacheMap` to `null`.
   | *cacheKeyFn* | Function | `key => key` | Produces cache key for a given load key. Useful when objects are keys and two objects should be considered equivalent.
-  | *cacheMap* | Object | `new Map()` | Instance of [Map][] (or an object with a similar API) to be used as cache.
+  | *cacheMap* | Object | `new Map()` | Instance of [Map][] (or an object with a similar API) to be used as cache. May be set to `null` to disable caching.
 
 ##### `load(key)`
 

--- a/src/__tests__/abuse.test.js
+++ b/src/__tests__/abuse.test.js
@@ -170,4 +170,24 @@ describe('Provides descriptive error messages for API abuse', () => {
       'Custom cacheMap missing methods: set, delete, clear'
     );
   });
+
+  it('Requires a number for maxBatchSize', () => {
+    expect(() =>
+      // $FlowExpectError
+      new DataLoader(async keys => keys, { maxBatchSize: null })
+    ).toThrow('maxBatchSize must be a positive number: null');
+  });
+
+  it('Requires a positive number for maxBatchSize', () => {
+    expect(() =>
+      new DataLoader(async keys => keys, { maxBatchSize: 0 })
+    ).toThrow('maxBatchSize must be a positive number: 0');
+  });
+
+  it('Requires a function for cacheKeyFn', () => {
+    expect(() =>
+      // $FlowExpectError
+      new DataLoader(async keys => keys, { cacheKeyFn: null })
+    ).toThrow('cacheKeyFn must be a function: null');
+  });
 });

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -46,6 +46,21 @@ describe('Primary API', () => {
     expect(that).toBe(loader);
   });
 
+  it('references the loader as "this" in the cache key function', async () => {
+    let that;
+    const loader = new DataLoader<number, number>(async keys => keys, {
+      cacheKeyFn(key) {
+        that = this;
+        return key;
+      }
+    });
+
+    // Trigger the cache key function
+    await loader.load(1);
+
+    expect(that).toBe(loader);
+  });
+
   it('supports loading multiple keys in one call', async () => {
     const identityLoader = new DataLoader<number, number>(async keys => keys);
 
@@ -656,6 +671,15 @@ describe('Accepts options', () => {
     expect(loadCalls).toEqual([
       [ 'A', 'C', 'D', 'C', 'D', 'A', 'A', 'B' ]
     ]);
+  });
+
+  it('cacheMap may be set to null to disable cache', async () => {
+    const [ identityLoader, loadCalls ] = idLoader<string>({ cacheMap: null });
+
+    await identityLoader.load('A');
+    await identityLoader.load('A');
+
+    expect(loadCalls).toEqual([ [ 'A' ], [ 'A' ] ]);
   });
 
   it('Does not interact with a cache when cache is disabled', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -78,39 +78,36 @@ declare namespace DataLoader {
   export type Options<K, V, C = K> = {
 
     /**
-     * Default `true`. Set to `false` to disable batching,
-     * instead immediately invoking `batchLoadFn` with a
-     * single load key.
+     * Default `true`. Set to `false` to disable batching, invoking
+     * `batchLoadFn` with a single load key. This is equivalent to setting
+     * `maxBatchSize` to `1`.
      */
     batch?: boolean,
 
     /**
-     * Default `Infinity`. Limits the number of items that get
-     * passed in to the `batchLoadFn`.
+     * Default `Infinity`. Limits the number of items that get passed in to the
+     * `batchLoadFn`. May be set to `1` to disable batching.
      */
     maxBatchSize?: number;
 
     /**
-     * Default `true`. Set to `false` to disable memoization caching,
-     * instead creating a new Promise and new key in the `batchLoadFn` for every
-     * load of the same key.
+     * Default `true`. Set to `false` to disable memoization caching, creating a
+     * new Promise and new key in the `batchLoadFn` for every load of the same
+     * key. This is equivalent to setting `cacheMap` to `null`.
      */
     cache?: boolean,
 
     /**
-     * A function to produce a cache key for a given load key.
-     * Defaults to `key => key`. Useful to provide when JavaScript
-     * objects are keys and two similarly shaped objects should
-     * be considered equivalent.
+     * Default `key => key`. Produces cache key for a given load key. Useful
+     * when objects are keys and two objects should be considered equivalent.
      */
     cacheKeyFn?: (key: K) => C,
 
     /**
-     * An instance of Map (or an object with a similar API) to
-     * be used as the underlying cache for this loader.
-     * Default `new Map()`.
+     * Default `new Map()`. Instance of `Map` (or an object with a similar API)
+     * to be used as cache. May be set to `null` to disable caching.
      */
-    cacheMap?: CacheMap<C, Promise<V>>;
+    cacheMap?: CacheMap<C, Promise<V>> | null;
   }
 }
 


### PR DESCRIPTION
Rather than holding a reference to the provided options and computing behaviors and defaults on the fly, this validates and extracts all options during construction.

Minor additional behavioral changes include allowing `cacheMap` to be set to `null` as an equivalence to `cache: false` and providing the DataLoader instance as `this` to `cacheKeyFn` to be consistent with doing the same for `batchLoadFn`.

Finally, this adds additional tests and makes minor edits to documentation.