### PR TITLE
[BREAKING] Update types to allow array of promises in batchLoadFn return

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ access permissions and consider creating a new instance per web request.
 Create a new `DataLoader` given a batch loading function and options.
 
 - *batchLoadFn*: A function which accepts an Array of keys, and returns a
-  Promise which resolves to an Array of values.
+  Promise which resolves to an Array of values or promises which resolve to
+  values.
 
 - *options*: An optional object of options:
 

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -91,6 +91,23 @@ describe('Primary API', () => {
     expect(values).toEqual([ 'a', 'b', new Error('Bad Key') ]);
   });
 
+  it('supports loading with resolved and rejected promises', async () => {
+    const identityLoader = new DataLoader(keys =>
+      Promise.resolve(
+        keys.map(key => (key === 'bad' ?
+          Promise.reject(new Error('Bad Key')) :
+          Promise.resolve(key))
+        )
+      )
+    );
+
+    const promiseAll = identityLoader.loadMany([ 'a', 'b', 'bad' ]);
+    expect(promiseAll).toBeInstanceOf(Promise);
+
+    const values = await promiseAll;
+    expect(values).toEqual([ 'a', 'b', new Error('Bad Key') ]);
+  });
+
   it('batches multiple requests', async () => {
     const [ identityLoader, loadCalls ] = idLoader<number>();
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@
 // A Function, which when given an Array of keys, returns a Promise of an Array
 // of values or Errors.
 export type BatchLoadFn<K, V> =
-  (keys: $ReadOnlyArray<K>) => Promise<$ReadOnlyArray<V | Error>>;
+  (keys: $ReadOnlyArray<K>) => Promise<$ReadOnlyArray<V | Promise<V> | Error>>;
 
 // Optionally turn off batching or caching or provide a cache key function or a
 // custom cache instance.


### PR DESCRIPTION
Update types to allow `batchLoadFn`s to resolve with an array of promises (this is already functionally supported).

This is a breaking change because it changes the batchLoadFn signature which will likely require code changes for some implementations.

Closes #247 