### PR TITLE
Standardize copyright attribution - "GraphQL Foundation" -> "GraphQL Contributors"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2015-2018, Facebook, Inc.
-Copyright (c) 2019-present, GraphQL Foundation
+Copyright (c) 2019-present, GraphQL Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Noticed this inconsistency whilst reviewing https://github.com/graphql/graphql.github.io/pull/943; I think we're trying to standardize around [`GraphQL Contributors`](https://github.com/graphql/foundation/blob/master/copyright-notices.md#copyright-notices) phrase? ([See also.](https://github.com/graphql/graphql-wg/blob/c3dda0548c8b7114ee693bf7334ba714575dce70/notes/2020-09-03.md#scalars-subproject-andreas-marek))

cc @brianwarner and @caniszczyk for sign-off.