### PR TITLE
Fix typo in examples/SQL.md

### DIFF
--- a/examples/SQL.md
+++ b/examples/SQL.md
@@ -18,7 +18,7 @@ const userLoader = new DataLoader(ids => new Promise((resolve, reject) => {
       reject(error);
     } else {
       resolve(ids.map(
-        id => rows.find(row => rows.id === id) || new Error(`Row not found: ${id}`)
+        id => rows.find(row => row.id === id) || new Error(`Row not found: ${id}`)
       ));
     }
   });


### PR DESCRIPTION
Hello, I think I just found a small typo in the SQL examples.

Here it is this small PR in case you want to merge it.

Have a great day!