### PR TITLE
Support browsers who do not support setImmediate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,9 @@ var enqueuePostPromiseJob =
         process.nextTick(fn);
       });
     } :
-    setImmediate || setTimeout;
+    typeof setImmediate === 'function' ?
+      setImmediate :
+      fn => { setTimeout(fn, 0); };
 
 // Private: cached resolved Promise instance
 var resolvedPromise;

--- a/src/index.js
+++ b/src/index.js
@@ -240,7 +240,7 @@ var enqueuePostPromiseJob =
       });
     } :
     typeof setImmediate === 'function' ?
-      setImmediate :
+      fn => { setImmediate(fn); } :
       fn => { setTimeout(fn, 0); };
 
 // Private: cached resolved Promise instance


### PR DESCRIPTION
This pull request allows browsers who don't support `setImmediate` to fallback to `setTimeout`.

This pull request also rescue IE, who doesn't support `setImmediate` call on non-`window` object.

Fixes #249