### PR TITLE
Use Tuples instead of ArrayLike types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,7 +37,7 @@ declare class DataLoader<K, V, C = K> {
    *     ]);
    *
    */
-  loadMany(keys: ArrayLike<K>): Promise<Array<V | Error>>;
+  loadMany(keys: [K, ...Array<K>]): Promise<[V | Error, ...Array<V | Error>]>;
 
   /**
    * Clears the value at `key` from the cache, if it exists. Returns itself for
@@ -70,8 +70,9 @@ declare namespace DataLoader {
 
   // A Function, which when given an Array of keys, returns a Promise of an Array
   // of values or Errors.
-  export type BatchLoadFn<K, V> =
-    (keys: ReadonlyArray<K>) => PromiseLike<ArrayLike<V | Error>>;
+  export type BatchLoadFn<K, V> = (
+    keys: readonly [K, ...Array<K>]
+  ) => PromiseLike<[V | Error, ...Array<V | Error>]>;
 
   // Optionally turn off batching or caching or provide a cache key function or a
   // custom cache instance.


### PR DESCRIPTION
Assume the following code:

```ts
const loadResults = (): Promise<Array<Result | Error>> => {
  const [a, b] = loader.loadMany(["1", "2"]);

  // TypeError: "a" and "b" can both be undefined
  if (a.prop === b.prop) {
    return [a];
  }

  return [a, b];
}
```

In the above code, both `a` and `b` can be `undefined` because the `ArrayLike` type does not guarantee the presence of any element; basically, `loadMany` could still be an empty array (based on the type). However, based on the logic implemented in this library, I believe the number of results will **always** match the number of keys in the input. Hence, the use of tuples makes more sense, in my opinion.

What do you think?