### PR TITLE
feat: add option for returning object as a result of batchFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Create a new `DataLoader` given a batch loading function and options.
   | *cache* | Boolean | `true` | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key. This is equivalent to setting `cacheMap` to `null`.
   | *cacheKeyFn* | Function | `key => key` | Produces cache key for a given load key. Useful when objects are keys and two objects should be considered equivalent.
   | *cacheMap* | Object | `new Map()` | Instance of [Map][] (or an object with a similar API) to be used as cache. May be set to `null` to disable caching.
+  | *objectResult* | Boolean | `false` | Set to `true` to return an object in `batchFn` with `key` as `cacheKey` and the value of the `key` is the actual value.
 
 ##### `load(key)`
 

--- a/src/__tests__/abuse.test.js
+++ b/src/__tests__/abuse.test.js
@@ -156,6 +156,29 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
   });
 
+  it(
+    'Batch function must promise an Object if objectResult is true',
+    async () => {
+    // Note: this resolves to empty array
+      const badLoader = new DataLoader<number, number>(async () => [],
+        { objectResult: true }
+      );
+
+      let caughtError;
+      try {
+        await badLoader.load(1);
+      } catch (error) {
+        caughtError = error;
+      }
+      expect(caughtError).toBeInstanceOf(Error);
+      expect((caughtError: any).message).toBe(
+        'DataLoader must be constructed with a function which accepts ' +
+        'Array<key> and returns Promise<Record<key, value>>,' +
+        'but the function did not return a Promise of an Object: ' +
+        '.'
+      );
+    });
+
   it('Cache should have get, set, delete, and clear methods', async () => {
     class IncompleteMap {
       get() {}

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -723,6 +723,25 @@ describe('Accepts options', () => {
     expect(loadCalls).toEqual([ [ 'A', 'B' ], [ 'A', 'B' ] ]);
   });
 
+  it('Return objects as a result of batchFn', async () => {
+    const identityLoader = new DataLoader<Obj, Obj, string>(() => {
+      return Promise.resolve({
+        A: 'a',
+        C: 'c'
+      });
+    }, { objectResult: true });
+
+    const [ valueA, valueB, valueC ] = await Promise.all([
+      identityLoader.load('A'),
+      identityLoader.load('B'),
+      identityLoader.load('C'),
+    ]);
+
+    expect(valueA).toBe('a');
+    expect(valueB).toBeUndefined();
+    expect(valueC).toBe('c');
+  });
+
   describe('Accepts object key in custom cacheKey function', () => {
     function cacheKey(key: {[string]: any}): string {
       return Object.keys(key).sort().map(k => k + ':' + key[k]).join();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,7 +71,7 @@ declare namespace DataLoader {
   // A Function, which when given an Array of keys, returns a Promise of an Array
   // of values or Errors.
   export type BatchLoadFn<K, V> =
-    (keys: ReadonlyArray<K>) => PromiseLike<ArrayLike<V | Error>>;
+    (keys: ReadonlyArray<K>) => PromiseLike<ArrayLike<V | Error> | Record<string, V | Error>>;
 
   // Optionally turn off batching or caching or provide a cache key function or a
   // custom cache instance.
@@ -115,6 +115,13 @@ declare namespace DataLoader {
      * to be used as cache. May be set to `null` to disable caching.
      */
     cacheMap?: CacheMap<C, Promise<V>> | null;
+
+    /**
+     * Set to `true` to return an
+     * object in `batchFn` with `key` as `cacheKey` and
+     * the value of the `key` is the actual value.
+     */
+    objectResult?: boolean,
   }
 }
 


### PR DESCRIPTION
This PR will allow returning an object instead of an array.

https://github.com/graphql/dataloader/issues/274