### PR TITLE
chore: update flow-bin dependency

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,5 +10,4 @@
 [libs]
 
 [options]
-suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 include_warnings=true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-eslint": "10.0.3",
     "coveralls": "3.0.7",
     "eslint": "6.6.0",
-    "flow-bin": "0.112.0",
+    "flow-bin": "0.167.0",
     "jest": "24.9.0",
     "sane": "4.1.0"
   }

--- a/src/__tests__/abuse.test.js
+++ b/src/__tests__/abuse.test.js
@@ -13,7 +13,7 @@ describe('Provides descriptive error messages for API abuse', () => {
 
   it('Loader creation requires a function', () => {
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       new DataLoader(); // eslint-disable-line no-new
     }).toThrow(
       'DataLoader must be constructed with a function which accepts ' +
@@ -21,7 +21,7 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
 
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[prop-missing]
       new DataLoader({}); // eslint-disable-line no-new
     }).toThrow(
       'DataLoader must be constructed with a function which accepts ' +
@@ -33,7 +33,7 @@ describe('Provides descriptive error messages for API abuse', () => {
     const idLoader = new DataLoader<number, number>(async keys => keys);
 
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       idLoader.load();
     }).toThrow(
       'The loader.load() function must be called with a value, ' +
@@ -41,7 +41,7 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
 
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       idLoader.load(null);
     }).toThrow(
       'The loader.load() function must be called with a value, ' +
@@ -58,7 +58,7 @@ describe('Provides descriptive error messages for API abuse', () => {
     const idLoader = new DataLoader<number, number>(async keys => keys);
 
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       idLoader.loadMany();
     }).toThrow(
       'The loader.loadMany() function must be called with Array<key> ' +
@@ -66,7 +66,8 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
 
     expect(() => {
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
+      // $FlowExpectedError[extra-arg]
       idLoader.loadMany(1, 2, 3);
     }).toThrow(
       'The loader.loadMany() function must be called with Array<key> ' +
@@ -80,7 +81,7 @@ describe('Provides descriptive error messages for API abuse', () => {
   });
 
   it('Batch function must return a Promise, not null', async () => {
-    // $FlowExpectError
+    // $FlowExpectedError[incompatible-call]
     const badLoader = new DataLoader<number, number>(() => null);
 
     let caughtError;
@@ -99,7 +100,7 @@ describe('Provides descriptive error messages for API abuse', () => {
 
   it('Batch function must return a Promise, not a value', async () => {
     // Note: this is returning the keys directly, rather than a promise to keys.
-    // $FlowExpectError
+    // $FlowExpectedError[incompatible-call]
     const badLoader = new DataLoader<number, number>(keys => keys);
 
     let caughtError;
@@ -118,7 +119,7 @@ describe('Provides descriptive error messages for API abuse', () => {
 
   it('Batch function must return a Promise of an Array, not null', async () => {
     // Note: this resolves to undefined
-    // $FlowExpectError
+    // $FlowExpectedError[incompatible-call]
     const badLoader = new DataLoader<number, number>(async () => null);
 
     let caughtError;
@@ -162,9 +163,9 @@ describe('Provides descriptive error messages for API abuse', () => {
     }
 
     expect(() => {
-      // $FlowExpectError
       const incompleteMap = new IncompleteMap();
       const options = { cacheMap: incompleteMap };
+      // $FlowExpectedError[incompatible-call]
       new DataLoader(async keys => keys, options); // eslint-disable-line no-new
     }).toThrow(
       'Custom cacheMap missing methods: set, delete, clear'
@@ -173,7 +174,7 @@ describe('Provides descriptive error messages for API abuse', () => {
 
   it('Requires a number for maxBatchSize', () => {
     expect(() =>
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       new DataLoader(async keys => keys, { maxBatchSize: null })
     ).toThrow('maxBatchSize must be a positive number: null');
   });
@@ -186,14 +187,14 @@ describe('Provides descriptive error messages for API abuse', () => {
 
   it('Requires a function for cacheKeyFn', () => {
     expect(() =>
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       new DataLoader(async keys => keys, { cacheKeyFn: null })
     ).toThrow('cacheKeyFn must be a function: null');
   });
 
   it('Requires a function for batchScheduleFn', () => {
     expect(() =>
-      // $FlowExpectError
+      // $FlowExpectedError[incompatible-call]
       new DataLoader(async keys => keys, { batchScheduleFn: null })
     ).toThrow('batchScheduleFn must be a function: null');
   });

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -50,6 +50,7 @@ describe('Primary API', () => {
     let that;
     const loader = new DataLoader<number, number>(async keys => keys, {
       cacheKeyFn(key) {
+        // $FlowIgnore[object-this-reference]
         that = this;
         return key;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,12 @@ export type Options<K, V, C = K> = {
 };
 
 // If a custom cache is provided, it must be of this type (a subset of ES6 Map).
-export type CacheMap<K, V> = {
+export interface CacheMap<K, V> {
   get(key: K): V | void;
   set(key: K, value: V): any;
   delete(key: K): any;
   clear(): any;
-};
+}
 
 /**
  * A `DataLoader` creates a public API for loading data from a particular
@@ -303,6 +303,7 @@ function dispatchBatch<K, V>(
   var batchPromise = loader._batchLoadFn(batch.keys);
 
   // Assert the expected response from batchLoadFn
+  // $FlowIgnore[method-unbinding]
   if (!batchPromise || typeof batchPromise.then !== 'function') {
     return failedDispatch(loader, batch, new TypeError(
       'DataLoader must be constructed with a function which accepts ' +
@@ -435,6 +436,7 @@ function getValidCacheMap<K, V, C>(
   if (cacheMap !== null) {
     var cacheFunctions = [ 'get', 'set', 'delete', 'clear' ];
     var missingFunctions = cacheFunctions
+      // $FlowIgnore[prop-missing]
       .filter(fnName => cacheMap && typeof cacheMap[fnName] !== 'function');
     if (missingFunctions.length !== 0) {
       throw new TypeError(
@@ -452,6 +454,7 @@ function isArrayLike(x: mixed): boolean {
     x !== null &&
     typeof x.length === 'number' &&
     (x.length === 0 ||
+      // $FlowIgnore[method-unbinding]
       (x.length > 0 && Object.prototype.hasOwnProperty.call(x, x.length - 1)))
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,10 +2010,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.112.0:
-  version "0.112.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
-  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
+flow-bin@0.167.0:
+  version "0.167.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.167.0.tgz#65f42d962707b015f6165b2f3536c4a8701fa929"
+  integrity sha512-/J64i+BN1Y8xzpdzRsML/Mij/k2G1d0UGUnMBUxN8ALrClPTQOxsOgDlh9wpEzNM/5yY7iu6eQYw8TnLbw6H5Q==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
In order to support specifying "this" type for a function

Updated to the latest version (0.167.0), though, v0.154.0 is sufficient.