### PR TITLE
Fix setImmediate and setTimeout issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,11 @@ var enqueuePostPromiseJob =
         process.nextTick(fn);
       });
     } :
-    setImmediate || setTimeout;
+    typeof setImmediate === 'function' ? function (fn) {
+      setImmediate(fn);
+    } : function (fn) {
+      setTimeout(fn);
+    };
 
 // Private: cached resolved Promise instance
 var resolvedPromise;


### PR DESCRIPTION
Most of the browsers don't have `setImmediate`. `setImmediate || setTimeout` doesn't work and it throws `setImmediate is not defined` in this case, so we should check `setImmediate` with `typeof`.
And some environments like Cloudflare Workers don't allow you to set `setTimeout` directly to another variable.
This PR fixes both of these issues.