### PR TITLE
fix: propagate batchFn sync throws to the loader instead of crashing

### DIFF
--- a/.changeset/lovely-grapes-bake.md
+++ b/.changeset/lovely-grapes-bake.md
@@ -1,0 +1,5 @@
+---
+"dataloader": patch
+---
+
+Fix the propagation of sync throws in the batch function to the loader function instead of crashing the process wtih an uncaught exception.

--- a/src/__tests__/abuse.test.js
+++ b/src/__tests__/abuse.test.js
@@ -97,6 +97,26 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
   });
 
+  it('Batch function must return a Promise, not error synchronously', async () => {
+    // $FlowExpectError
+    const badLoader = new DataLoader<number, number>(() => {
+      throw new Error("Mock Synchronous Error")
+    });
+
+    let caughtError;
+    try {
+      await badLoader.load(1);
+    } catch (error) {
+      caughtError = error;
+    }
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError: any).message).toBe(
+      'DataLoader must be constructed with a function which accepts ' +
+      'Array<key> and returns Promise<Array<value>>, but the function ' +
+      `errored synchronously: Error: Mock Synchronous Error.`
+    );
+  });
+
   it('Batch function must return a Promise, not a value', async () => {
     // Note: this is returning the keys directly, rather than a promise to keys.
     // $FlowExpectError

--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,16 @@ function dispatchBatch<K, V>(
 
   // Call the provided batchLoadFn for this loader with the batch's keys and
   // with the loader as the `this` context.
-  var batchPromise = loader._batchLoadFn(batch.keys);
+  var batchPromise;
+  try {
+    batchPromise = loader._batchLoadFn(batch.keys);
+  } catch (e) {
+    return failedDispatch(loader, batch, new TypeError(
+      'DataLoader must be constructed with a function which accepts ' +
+      'Array<key> and returns Promise<Array<value>>, but the function ' +
+      `errored synchronously: ${String(e)}.`
+    ));
+  }
 
   // Assert the expected response from batchLoadFn
   if (!batchPromise || typeof batchPromise.then !== 'function') {


### PR DESCRIPTION
If the batch load function throws synchronously, the error is not caught anywhere in the load pipeline. A synchronous error in the batchLoadFn cannot be caught. It crashes the server as an uncaught exception. Since the batchLoadFn is invoked as a result of `.load` the errors happening inside should also be available at the `.load` call.

This PR fixes this issue by wrapping a try catch around the batchLoadFn call and returning a failed dispatch.

```js
const loader = new Dataloader( keys => {
  const mergedKeys = functionThatCanThrowSynchronously(keys);
  // correctly returns a Promise as expected by the Dataloader
  return fetch(mergedKeys).then(mergedValues => split(mergedValues));
});
```

For example, consider the following minimal repro - 

```js
const loader = new DataLoader(() => {
  throw new Error("mock error");
});

try {
  loader.load(1).catch(e => {
    // mock error will not be caught here
  })
} catch (e) {
  // mock error will also not be caught here
}
```

With this PR, the "mock error" would be caught in the `load.catch` handler.