### PR TITLE
Fixes #294.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,9 +268,7 @@ function getCurrentBatch<K, V>(loader: DataLoader<K, V, any>): Batch<K, V> {
   if (
     existingBatch !== null &&
     !existingBatch.hasDispatched &&
-    existingBatch.keys.length < loader._maxBatchSize &&
-    (!existingBatch.cacheHits ||
-      existingBatch.cacheHits.length < loader._maxBatchSize)
+    existingBatch.keys.length < loader._maxBatchSize
   ) {
     return existingBatch;
   }


### PR DESCRIPTION
This PR fixes #294.

It should be noted that this also amends the `max batch size respects cached results` test at this change slightly changes the moment when the first batch is resolved, but the DataLoader still does respect cached results, and the load call in that test is still only called to request `2`. Happy to do this a different / better way, but this seemed the most straightforward to me.