### PR TITLE
feat: add `name` to `DataLoader`

### DIFF
--- a/.changeset/wet-melons-wash.md
+++ b/.changeset/wet-melons-wash.md
@@ -1,0 +1,5 @@
+---
+"dataloader": minor
+---
+
+Add `name` property to `DataLoader`. Useful in APM tools.

--- a/README.md
+++ b/README.md
@@ -393,14 +393,15 @@ Create a new `DataLoader` given a batch loading function and options.
 
 - *options*: An optional object of options:
 
-  | Option Key | Type | Default | Description |
-  | ---------- | ---- | ------- | ----------- |
-  | *batch*  | Boolean | `true` | Set to `false` to disable batching, invoking `batchLoadFn` with a single load key. This is equivalent to setting `maxBatchSize` to `1`.
-  | *maxBatchSize* | Number | `Infinity` | Limits the number of items that get passed in to the `batchLoadFn`. May be set to `1` to disable batching.
-  | *batchScheduleFn* | Function | See [Batch scheduling](#batch-scheduling) | A function to schedule the later execution of a batch. The function is expected to call the provided callback in the immediate future.
-  | *cache* | Boolean | `true` | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key. This is equivalent to setting `cacheMap` to `null`.
-  | *cacheKeyFn* | Function | `key => key` | Produces cache key for a given load key. Useful when objects are keys and two objects should be considered equivalent.
-  | *cacheMap* | Object | `new Map()` | Instance of [Map][] (or an object with a similar API) to be used as cache. May be set to `null` to disable caching.
+| Option Key        | Type     | Default                                   | Description                                                                                                                                                                                |
+|-------------------|----------|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `batch`           | Boolean  | `true`                                    | Set to `false` to disable batching, invoking `batchLoadFn` with a single load key. This is equivalent to setting `maxBatchSize` to `1`.                                                    |
+| `maxBatchSize`    | Number   | `Infinity`                                | Limits the number of items that get passed in to the `batchLoadFn`. May be set to `1` to disable batching.                                                                                 |
+| `batchScheduleFn` | Function | See [Batch scheduling](#batch-scheduling) | A function to schedule the later execution of a batch. The function is expected to call the provided callback in the immediate future.                                                     |
+| `cache`           | Boolean  | `true`                                    | Set to `false` to disable memoization caching, creating a new Promise and new key in the `batchLoadFn` for every load of the same key. This is equivalent to setting `cacheMap` to `null`. |
+| `cacheKeyFn`      | Function | `key => key`                              | Produces cache key for a given load key. Useful when objects are keys and two objects should be considered equivalent.                                                                     |
+| `cacheMap`        | Object   | `new Map()`                               | Instance of [Map][] (or an object with a similar API) to be used as cache. May be set to `null` to disable caching.                                                                        |
+| `name`            | String   | `null`                                    | The name given to this `DataLoader` instance. Useful for APM tools.                                                                                                                        |
 
 ##### `load(key)`
 

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -412,6 +412,14 @@ describe('Primary API', () => {
     expect(loadCalls).toEqual([ [ 'B' ] ]);
   });
 
+  it('allows giving the loader a name', () => {
+    expect(new DataLoader(() => []).name).toBeNull();
+    expect(new DataLoader(() => [], {}).name).toBeNull();
+
+    expect(new DataLoader(() => [], { name: 'Some name' }).name).toBe(
+      'Some name'
+    );
+  });
 });
 
 describe('Represents Errors', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -115,6 +115,13 @@ declare namespace DataLoader {
      * to be used as cache. May be set to `null` to disable caching.
      */
     cacheMap?: CacheMap<C, Promise<V>> | null;
+
+    /**
+     * The name given to this `DataLoader` instance. Useful for APM tools.
+     *
+     * Is `null` if not set in the constructor.
+     */
+    name: string | null;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export type Options<K, V, C = K> = {
   cache?: boolean;
   cacheKeyFn?: (key: K) => C;
   cacheMap?: CacheMap<C, Promise<V>> | null;
+  name?: string;
 };
 
 // If a custom cache is provided, it must be of this type (a subset of ES6 Map).
@@ -58,6 +59,7 @@ class DataLoader<K, V, C = K> {
     this._cacheKeyFn = getValidCacheKeyFn(options);
     this._cacheMap = getValidCacheMap(options);
     this._batch = null;
+    this.name = getValidName(options);
   }
 
   // Private
@@ -201,6 +203,13 @@ class DataLoader<K, V, C = K> {
     }
     return this;
   }
+
+  /**
+   * The name given to this `DataLoader` instance. Useful for APM tools.
+   *
+   * Is `null` if not set in the constructor.
+   */
+  name: string | null;
 }
 
 // Private: Enqueue a Job to be executed after all "PromiseJobs" Jobs.
@@ -454,6 +463,16 @@ function getValidCacheMap<K, V, C>(
     }
   }
   return cacheMap;
+}
+
+function getValidName<K, V, C>(
+  options: ?Options<K, V, C>
+): string | null {
+  if (options && options.name) {
+    return options.name;
+  }
+
+  return null;
 }
 
 // Private


### PR DESCRIPTION
I came over https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1345 and figured having that just get the name from the data loader instead of creating an indirection seems a cleaner concept.