### PR TITLE
Update tested node versions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [14, 16, 18, 19]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Node 12 is end-of-life so I propose to drop it from tests.

Node 18 should be added as the LTS version, and.

Node 19 should replace Node 17 as the current version.