### PR TITLE
fix: expose `name` in Dataloader instance types

### DIFF
--- a/.changeset/rare-planes-stare.md
+++ b/.changeset/rare-planes-stare.md
@@ -1,0 +1,5 @@
+---
+'dataloader': patch
+---
+
+Added missing type definition for Dataloader.name

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,6 +59,14 @@ declare class DataLoader<K, V, C = K> {
    * change is made. Returns itself for method chaining.
    */
   prime(key: K, value: V | PromiseLike<V> | Error): this;
+
+
+  /**
+   * The name given to this `DataLoader` instance. Useful for APM tools.
+   *
+   * Is `null` if not set in the constructor.
+   */
+  name: string | null;
 }
 
 declare namespace DataLoader {


### PR DESCRIPTION
Followup to #331 and #326

This corrects the types, as the name property is also exposed on the Dataloader instance, not only in the config. Tests already test for this, but as they are not in TS, the types were not checked.