### PR TITLE
fix:readme-typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ data sources such as databases or web services via batching and caching.
 [![Build Status](https://travis-ci.org/graphql/dataloader.svg)](https://travis-ci.org/graphql/dataloader)
 [![Coverage Status](https://coveralls.io/repos/graphql/dataloader/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql/dataloader?branch=master)
 
-A port of the "Loader" API originally developed by [@schrockn][] at Facebook in
+A part of the "Loader" API originally developed by [@schrockn][] at Facebook in
 2010 as a simplifying force to coalesce the sundry key-value store back-end
 APIs which existed at the time. At Facebook, "Loader" became one of the
 implementation details of the "Ent" framework, a privacy-aware data entity


### PR DESCRIPTION
This is a fix a for a typo at the begining  of the read me,where its Port instead of Part.