### PR TITLE
perf: call cacheKeyFn only when it is needed (if caching)

### DIFF
--- a/.changeset/smooth-crabs-lie.md
+++ b/.changeset/smooth-crabs-lie.md
@@ -1,0 +1,5 @@
+---
+'dataloader': patch
+---
+
+Ensure `cacheKeyFn` is not called when caching is disabled, since the key is not utilized in that case.

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -750,6 +750,20 @@ describe('Accepts options', () => {
     expect(cacheMap.get('X')).toBe(promiseX);
   });
 
+  it('Does not call cacheKeyFn when cache is disabled', async () => {
+    const cacheKeyFnCalls = [];
+    const [identityLoader] = idLoader<string>({
+      cache: false,
+      cacheKeyFn: key => {
+        cacheKeyFnCalls.push(key);
+        return key;
+      },
+    });
+
+    await identityLoader.load('A');
+    expect(cacheKeyFnCalls).toEqual([]);
+  });
+
   it('Complex cache behavior via clearAll()', async () => {
     // This loader clears its cache as soon as a batch function is dispatched.
     const loadCalls = [];

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ class DataLoader<K, V, C = K> {
 
     const batch = getCurrentBatch(this);
     const cacheMap = this._cacheMap;
-    let cacheKey;
+    let cacheKey: ?C;
 
     // If caching and there is a cache-hit, return cached Promise.
     if (cacheMap) {
@@ -106,7 +106,7 @@ class DataLoader<K, V, C = K> {
 
     // If caching, cache this promise.
     if (cacheMap) {
-      cacheMap.set(cacheKey, promise);
+      cacheMap.set((cacheKey: any), promise);
     }
 
     return promise;

--- a/src/index.js
+++ b/src/index.js
@@ -81,10 +81,11 @@ class DataLoader<K, V, C = K> {
 
     const batch = getCurrentBatch(this);
     const cacheMap = this._cacheMap;
-    const cacheKey = this._cacheKeyFn(key);
+    let cacheKey;
 
     // If caching and there is a cache-hit, return cached Promise.
     if (cacheMap) {
+      cacheKey = this._cacheKeyFn(key);
       const cachedPromise = cacheMap.get(cacheKey);
       if (cachedPromise) {
         const cacheHits = batch.cacheHits || (batch.cacheHits = []);


### PR DESCRIPTION
Previously `cacheKeyFn` was called unnecessarily with caching disabled as `cacheKey` was never used in such case. This PR makes sure `cacheKeyFn` is called only when caching is enabled and `cacheKey` is actually needed. Sometimes `cacheKeyFn` can use more expensive code, such as `JSON.stringify`, in which case it is preferred not to waste CPU cycles. 