### PR TITLE
Update readme badge to use GitHub CI instead of unused Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DataLoader is a generic utility to be used as part of your application's data
 fetching layer to provide a simplified and consistent API over various remote
 data sources such as databases or web services via batching and caching.
 
-[![Build Status](https://travis-ci.org/graphql/dataloader.svg)](https://travis-ci.org/graphql/dataloader)
+[![Build Status](https://github.com/graphql/dataloader/actions/workflows/validation.yml/badge.svg)](https://github.com/graphql/dataloader/actions/workflows/validation.yml)
 [![Coverage Status](https://coveralls.io/repos/graphql/dataloader/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql/dataloader?branch=main)
 
 A port of the "Loader" API originally developed by [@schrockn][] at Facebook in


### PR DESCRIPTION
While observing if there are any other mentions for unused Travis I found that it's mentioned here https://github.com/graphql/dataloader/blob/55c33d480cdf429a0b24cf607ddd0e892521a35b/resources/prepublish.sh#L7

But this script was probably not used at all because for publishing in NPM, it used Github action without `prepublish` script https://github.com/graphql/dataloader/blob/55c33d480cdf429a0b24cf607ddd0e892521a35b/.github/workflows/release.yml#L8-L17

Should I drop all mentions about prepublish script?

----

Another observation - another abandoned badge - about code coverage (current badge leads to **coveralls**, but in workflow **codecov** is used).

To fix this badge it's needed to copy the link from **codecov** repo settings https://docs.codecov.com/docs/status-badges

https://app.codecov.io/github/graphql/dataloader/commits?branch=main

Should I drop **coveralls** badge at all?