### PR TITLE
Fix Incorrect suffix check

### DIFF
--- a/resources/watch.js
+++ b/resources/watch.js
@@ -171,7 +171,7 @@ function srcPath(filepath) {
 // Predicates
 
 function isJS(filepath) {
-  return filepath.indexOf('.js') === filepath.length - 3;
+  return filepath.endsWith('.js');
 }
 
 function allTests(filepaths) {


### PR DESCRIPTION
The best way to fix this problem is to use `String.prototype.endsWith` if available, as it directly checks for a suffix. If you want to support older environments, you can fall back to a manual check that compares the substring at the end of the string to the desired suffix. In this case, since the code is using ES6 imports and other modern features, it is safe to use `endsWith`. The fix should be applied to the `isJS` function in `resources/watch.js`, replacing the current `indexOf` check with `filepath.endsWith('.js')`. No additional imports or definitions are needed.

### References
[String.prototype.endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith)
[String.prototype.indexOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf)